### PR TITLE
[RFR] AuthProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ A component for [Admin-on-rest](https://github.com/marmelab/admin-on-rest) allow
 
 - [Installation](#installation)
 - [Usage](#installation)
+- [API](#api)
+    - [SwitchPermissions](#switchpermissions)
+    - [Permission](#permission)
+    - [WithPermission](#withpermission)
+    - [AuthProvider](#authprovider)
 - [Options](#options)
 
 ## Installation
@@ -218,6 +223,28 @@ The `WithPermission` component accepts the following props:
 - `value`: the permissions to check (could be a role, an array of rules, etc) or a `resolver` function. (same as `Permission`)
 
 You can pass anything as children for this component: a view ([List](https://marmelab.com/admin-on-rest/List.html), [Create](https://marmelab.com/admin-on-rest/CreateEdit.html), [Edit](https://marmelab.com/admin-on-rest/CreateEdit.html)), an input, a React node, whatever.
+
+### AuthProvider
+
+Requiring and specifying the `authClient` for each `SwitchPermissions` and `WithPermission` components could be cumbersome. That's why we also provided an `AuthProvider` component.
+
+It must enclose the [Admin](https://marmelab.com/admin-on-rest/AdminResource.html#the-admin-component) component.
+
+It accepts a single prop: `authClient`.
+
+```js
+import { Admin, Resource } from 'admin-on-rest';
+import { AuthProvider } from 'aor-permissions';
+import authClient from './authClient';
+
+export const App = () => (
+    <AuthProvider authClient={authClient}>
+        <Admin>
+            {/* Usual Resource components */}
+        </Admin>
+    </AuthProvider>
+)
+```
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   "dependencies": {
     "babel-plugin-transform-runtime": "~6.23.0",
     "lodash.get": "~4.4.2",
-    "proptypes": "~1.0.0"
+    "proptypes": "~1.0.0",
+    "recompose": "^0.23.4"
   },
   "peerDependencies": {
     "admin-on-rest": "~0.9.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "admin-on-rest": "~1.0.2",
     "babel-cli": "~6.24.1",
     "babel-core": "~6.24.1",
-    "babel-eslint": "7.2.3",
+    "babel-eslint": "~7.2.3",
     "babel-plugin-istanbul": "~4.1.3",
     "babel-preset-es2015": "~6.24.1",
     "babel-preset-react": "~6.24.1",
@@ -52,7 +52,7 @@
     "babel-plugin-transform-runtime": "~6.23.0",
     "lodash.get": "~4.4.2",
     "proptypes": "~1.0.0",
-    "recompose": "^0.23.4"
+    "recompose": "~0.23.4"
   },
   "peerDependencies": {
     "admin-on-rest": "~0.9.1",

--- a/src/AuthProvider.js
+++ b/src/AuthProvider.js
@@ -1,0 +1,16 @@
+import { cloneElement } from 'react';
+import PropTypes from 'prop-types';
+import withContext from 'recompose/withContext';
+
+const AuthProviderComponent = ({ authClient, children }) => cloneElement(children, { authClient });
+
+AuthProviderComponent.propTypes = {
+    children: PropTypes.node.isRequired,
+};
+
+export default withContext(
+    {
+        authClient: PropTypes.func,
+    },
+    ({ authClient }) => ({ authClient }),
+)(AuthProviderComponent);

--- a/src/AuthProvider.js
+++ b/src/AuthProvider.js
@@ -8,9 +8,4 @@ AuthProviderComponent.propTypes = {
     children: PropTypes.node.isRequired,
 };
 
-export default withContext(
-    {
-        authClient: PropTypes.func,
-    },
-    ({ authClient }) => ({ authClient }),
-)(AuthProviderComponent);
+export default withContext({ authClient: PropTypes.func }, ({ authClient }) => ({ authClient }))(AuthProviderComponent);

--- a/src/SwitchPermissions.js
+++ b/src/SwitchPermissions.js
@@ -1,13 +1,14 @@
 import React, { createElement, Component } from 'react';
 import PropTypes from 'proptypes';
 import FormField from 'admin-on-rest/lib/mui/form/FormField';
+import getContext from 'recompose/getContext';
 
 import DefaultLoading from './Loading';
 import DefaultNotFound from './NotFound';
 import { AUTH_GET_PERMISSIONS } from './constants';
 import resolvePermissions from './resolvePermissions';
 
-export default class SwitchPermissions extends Component {
+export class SwitchPermissionsComponent extends Component {
     static propTypes = {
         authClient: PropTypes.func.isRequired,
         children: PropTypes.node.isRequired,
@@ -61,3 +62,7 @@ export default class SwitchPermissions extends Component {
         return <span>{React.Children.map(match, child => <FormField input={child} {...props} />)}</span>;
     }
 }
+
+export default getContext({
+    authClient: PropTypes.func,
+})(SwitchPermissionsComponent);

--- a/src/WithPermission.js
+++ b/src/WithPermission.js
@@ -29,11 +29,11 @@ export class WithPermissionComponent extends Component {
     };
 
     async componentWillMount() {
-        const { authClient, children, record, resource, value: requiredPersmissions, exact } = this.props;
+        const { authClient, children, record, resource, value: requiredPermissions, exact } = this.props;
         const permissions = await authClient(AUTH_GET_PERMISSIONS, { record, resource });
         const match = await resolvePermission({ permissions, record, resource })({
             exact,
-            permissions: requiredPersmissions,
+            permissions: requiredPermissions,
             view: children,
         });
 

--- a/src/WithPermission.js
+++ b/src/WithPermission.js
@@ -1,12 +1,13 @@
 import React, { createElement, Component } from 'react';
 import PropTypes from 'proptypes';
 import FormField from 'admin-on-rest/lib/mui/form/FormField';
+import getContext from 'recompose/getContext';
 
 import DefaultLoading from './Loading';
 import { AUTH_GET_PERMISSIONS } from './constants';
 import { resolvePermission } from './resolvePermissions';
 
-export default class WithPermission extends Component {
+export class WithPermissionComponent extends Component {
     static propTypes = {
         authClient: PropTypes.func.isRequired,
         children: PropTypes.node.isRequired,
@@ -14,6 +15,7 @@ export default class WithPermission extends Component {
         notFound: PropTypes.func,
         record: PropTypes.object,
         resource: PropTypes.string,
+        value: PropTypes.any.isRequired,
     };
 
     static defaultProps = {
@@ -27,7 +29,7 @@ export default class WithPermission extends Component {
     };
 
     async componentWillMount() {
-        const { authClient, children, record, resource, permissions: requiredPersmissions, exact } = this.props;
+        const { authClient, children, record, resource, value: requiredPersmissions, exact } = this.props;
         const permissions = await authClient(AUTH_GET_PERMISSIONS, { record, resource });
         const match = await resolvePermission({ permissions, record, resource })({
             exact,
@@ -61,3 +63,7 @@ export default class WithPermission extends Component {
         return <span>{React.Children.map(match, child => <FormField input={child} {...props} />)}</span>;
     }
 }
+
+export default getContext({
+    authClient: PropTypes.func,
+})(WithPermissionComponent);

--- a/src/index.js
+++ b/src/index.js
@@ -3,4 +3,5 @@ export WithPermission from './WithPermission';
 export Permission from './Permission';
 export NotFound from './NotFound';
 export Loading from './Loading';
+export AuthProvider from './AuthProvider';
 export { AUTH_GET_PERMISSIONS } from './constants';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1050,10 +1050,6 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chain-function@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.0.tgz#0d4ab37e7e18ead0bdc47b920764118ce58733dc"
-
 chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -1363,10 +1359,6 @@ doctrine@^2.0.0:
   dependencies:
     esutils "^2.0.2"
     isarray "^1.0.0"
-
-dom-helpers@^3.2.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -2697,22 +2689,6 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
 
-material-ui@^0.18.1:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-0.18.1.tgz#1c8a47d7e930ff0b07064dd8633035984a5a3569"
-  dependencies:
-    babel-runtime "^6.23.0"
-    inline-style-prefixer "^3.0.2"
-    keycode "^2.1.8"
-    lodash.merge "^4.6.0"
-    lodash.throttle "^4.1.1"
-    prop-types "^15.5.7"
-    react-event-listener "^0.4.5"
-    react-transition-group "^1.1.2"
-    recompose "0.23.4"
-    simple-assign "^0.1.0"
-    warning "^3.0.0"
-
 material-ui@~0.17.4:
   version "0.17.4"
   resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-0.17.4.tgz#193999ecb49c3ec15ae0abb4e90fdf9a7bd343e0"
@@ -3342,15 +3318,6 @@ react-tap-event-plugin@~2.0.1:
   dependencies:
     fbjs "^0.8.6"
 
-react-transition-group@^1.1.2:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.1.3.tgz#5e02cf6e44a863314ff3c68a0c826c2d9d70b221"
-  dependencies:
-    chain-function "^1.0.0"
-    dom-helpers "^3.2.0"
-    prop-types "^15.5.6"
-    warning "^3.0.0"
-
 react@~15.5.4:
   version "15.5.4"
   resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
@@ -3410,18 +3377,18 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
-recompose@0.23.4:
-  version "0.23.4"
-  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.23.4.tgz#af09e4e08424effa449c9b793037166f7b30644a"
+recompose@^0.23.0, recompose@~0.23.1:
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.23.1.tgz#577613e24a7ff56f9ca6b899190f8a9c0857fc20"
   dependencies:
     change-emitter "^0.1.2"
     fbjs "^0.8.1"
     hoist-non-react-statics "^1.0.0"
     symbol-observable "^1.0.4"
 
-recompose@^0.23.0, recompose@~0.23.1:
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.23.1.tgz#577613e24a7ff56f9ca6b899190f8a9c0857fc20"
+recompose@^0.23.4:
+  version "0.23.4"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.23.4.tgz#af09e4e08424effa449c9b793037166f7b30644a"
   dependencies:
     change-emitter "^0.1.2"
     fbjs "^0.8.1"


### PR DESCRIPTION
Follow #2 

Requiring and specifying the `authClient` for each `SwitchPermissions` and `WithPermission` components could be cumbersome. That's why we also provided an `AuthProvider` component.