### PR TITLE
Add import Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ A simpler component which will render its children only if its permissions are m
 
 ```js
 import React from 'react';
+import { Link } from 'react-router-dom';
 import MenuItem from 'material-ui/MenuItem';
 import SettingsIcon from 'material-ui/svg-icons/action/settings';
 import { WithPermission } from 'aor-permissions';


### PR DESCRIPTION
The Menu example with permissions was without the import of the react-router-dom component Link.