### PR TITLE
[RFR] Permissions on Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ First, the [authClient](https://marmelab.com/admin-on-rest/Authentication.html) 
 
 Here is a naive implementation using localstorage:
 
-```js
+```jsx
 // in authClient.js
 import { AUTH_LOGIN, AUTH_LOGOUT, AUTH_CHECK, AUTH_ERROR } from 'admin-on-rest';
 import { AUTH_GET_PERMISSIONS } from 'aor-permissions';
@@ -69,9 +69,9 @@ export default (type, params) => {
 
 Then, you may use the `SwitchPermissions` and `Permission` components:
 
-### Simple permissions check
+### Simple permissions check
 
-```js
+```jsx
 // In products.js
 import { SwitchPermissions, Permission } from 'aor-permissions';
 import authClient from '../authClient';
@@ -102,7 +102,7 @@ export const ProductEdit = props => (
 
 ### Permissions check depending on the resource/record
 
-```js
+```jsx
 // In products.js
 import { SwitchPermissions, Permission } from 'aor-permissions';
 import authClient from '../authClient';
@@ -136,6 +136,46 @@ export const PostEdit = props => (
         </SwitchPermissions>
     </Edit>
 );
+```
+
+### Protect access to resources
+
+```jsx
+import { Admin } from 'aor-permissions';
+import restClient from '../restClient';
+import authClient from '../authClient';
+import { PostList, PostEdit, PostCreate } from './posts';
+
+const resolveAccessToPosts = ({ resource, permissions, exact, value }) => {
+    // value = the requested permissions specified in the `permissions` prop (eg `admin`). May be undefined
+    // resource = the requested resource (eg `posts`)
+    // exact = the value of the `exact` prop
+    // permissions = the result of the authClient call
+};
+
+const resolveEditAccess = ({ resource, permissions, exact, value }) => {
+    // value = the requested permissions specified in the `permissions` prop (eg `admin`). May be undefined
+    // resource = the requested resource (eg `posts`)
+    // exact = the value of the `exact` prop
+    // permissions = the result of the authClient call
+};
+
+const App = () => (
+    <Admin restClient={restClient} authClient={authClient}>
+        <Resource
+            name="posts"
+            resolve={resolveAccessToPosts}
+            list={PostList}
+            edit={PostEdit}
+            editPermissions="admin"
+            editResolve={resolveEditAccess}
+            create={PostCreate}
+            createPermissions="admin"
+            createExact={true}
+        />
+    </Admin>
+);
+
 ```
 
 ## API
@@ -191,7 +231,7 @@ If multiple matches are found, the first one will be applied.
 
 A simpler component which will render its children only if its permissions are matched. For example, in a custom [Menu](https://marmelab.com/admin-on-rest/AdminResource.html#menu):
 
-```js
+```jsx
 import React from 'react';
 import { Link } from 'react-router-dom';
 import MenuItem from 'material-ui/MenuItem';
@@ -234,7 +274,7 @@ It must enclose the [Admin](https://marmelab.com/admin-on-rest/AdminResource.htm
 
 It accepts a single prop: `authClient`.
 
-```js
+```jsx
 import { Admin, Resource } from 'admin-on-rest';
 import { AuthProvider } from 'aor-permissions';
 import authClient from './authClient';
@@ -247,6 +287,28 @@ export const App = () => (
     </AuthProvider>
 )
 ```
+
+### Admin
+
+This component can be used instead of the default `Admin` component from `admin-on-rest`.
+
+It allows to define permissions on each resource and for each resource's view.
+
+It accepts the following props:
+
+- `permissions`: to define the permissions required for the whole resource
+- `resolve`: function called to check whether permissions for the whole resource are ok
+- `exact`: Boolean for exact match (useful when `permissions` is an array)
+
+If defined, the `resolve` function will be called with an object containing the following properties:
+
+- `permissions`: the result of the `authClient` call.
+- `value`: the value of the `permissions` prop: the requested permissions
+- `exact`: the value of the `exact` prop
+
+Additionnaly, the `Admin` components accepts for each view (list, create, edit and remove) the same three props prefixed with the view's name. For example: `listPermissions`, `listResolve` and `listExact`.
+
+**Note**: when using this custom `Admin` component, there's no need to use the `AuthProvider` too as it will be added automatically.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ export const PostEdit = props => (
 
 ```jsx
 import { Admin } from 'aor-permissions';
+import { Resource } from 'admin-on-rest';
 import restClient from '../restClient';
 import authClient from '../authClient';
 import { PostList, PostEdit, PostCreate } from './posts';

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -67,7 +67,7 @@ export const applyPermissionsToResources = async ({
     applyPermissionsToResource = defaultApplyPermissionsToResource,
 }) => {
     const newResources = await Promise.all(
-        Children.map(resources, resource => applyPermissionsToResource(authClient, resource)),
+        Children.map(resources, resource => applyPermissionsToResource({ authClient, resource })),
     );
 
     return newResources.filter(resource => !!resource);

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -3,10 +3,47 @@ import PropTypes from 'prop-types';
 import { Admin as OriginalAdmin, Resource } from 'admin-on-rest';
 import AuthProvider from './AuthProvider';
 import { AUTH_GET_PERMISSIONS } from './constants';
+import { resolvePermission as defaultResolvePermission } from './resolvePermissions';
 
-export const applyPermissionsToResource = async (authClient, resource) => {
-    if (resource.props.permission && !await authClient(AUTH_GET_PERMISSIONS, resource.props.permission)) {
-        return false;
+export const defaultApplyPermissionsToAction = async ({
+    permissions,
+    resource,
+    action,
+    resolvePermission = defaultResolvePermission,
+}) => {
+    if (resource.props[`${action}Permissions`]) {
+        const match = await resolvePermission({ permissions, resource })({
+            exact: resource.props[`${action}Exact`],
+            permissions: resource.props[`${action}Permissions`],
+            resolve: resource.props[`${action}Resolve`],
+            view: true,
+        });
+
+        return match.matched ? resource.props[action] : null;
+    }
+
+    return resource.props[action];
+};
+
+export const defaultApplyPermissionsToResource = async ({
+    authClient,
+    resource,
+    resolvePermission = defaultResolvePermission,
+    applyPermissionsToAction = defaultApplyPermissionsToAction,
+}) => {
+    const permissions = await authClient(AUTH_GET_PERMISSIONS, { resource });
+
+    if (resource.props.permissions) {
+        const match = await resolvePermission({ permissions, resource })({
+            exact: resource.props.exact,
+            permissions: resource.props.permissions,
+            resolve: resource.props.resolve,
+            view: true,
+        });
+
+        if (!match.matched) {
+            return false;
+        }
     }
 
     const newResource = {
@@ -14,29 +51,21 @@ export const applyPermissionsToResource = async (authClient, resource) => {
         icon: resource.props.icon,
         options: resource.props.options,
         checkCredentials: resource.props.checkCredentials,
-        list: !resource.props.listPermission || (await authClient(AUTH_GET_PERMISSIONS, resource.props.listPermission))
-            ? resource.props.list
-            : null,
-        create: !resource.props.createPermission ||
-            (await authClient(AUTH_GET_PERMISSIONS, resource.props.createPermission))
-            ? resource.props.create
-            : null,
-        edit: !resource.props.editPermission || (await authClient(AUTH_GET_PERMISSIONS, resource.props.editPermission))
-            ? resource.props.edit
-            : null,
-        show: !resource.props.showPermission || (await authClient(AUTH_GET_PERMISSIONS, resource.props.showPermission))
-            ? resource.props.show
-            : null,
-        remove: !resource.props.removePermission ||
-            (await authClient(AUTH_GET_PERMISSIONS, resource.props.removePermission))
-            ? resource.props.remove
-            : null,
+        list: await applyPermissionsToAction({ permissions, resource, action: 'list' }),
+        create: await applyPermissionsToAction({ permissions, resource, action: 'create' }),
+        edit: await applyPermissionsToAction({ permissions, resource, action: 'edit' }),
+        show: await applyPermissionsToAction({ permissions, resource, action: 'show' }),
+        remove: await applyPermissionsToAction({ permissions, resource, action: 'remove' }),
     };
 
     return newResource;
 };
 
-export const applyPermissionsToResources = async (authClient, resources) => {
+export const applyPermissionsToResources = async ({
+    authClient,
+    resources,
+    applyPermissionsToResource = defaultApplyPermissionsToResource,
+}) => {
     const newResources = await Promise.all(
         Children.map(resources, resource => applyPermissionsToResource(authClient, resource)),
     );
@@ -53,9 +82,9 @@ export default class Admin extends Component {
     state = { resources: false };
 
     componentWillMount() {
-        applyPermissionsToResources(this.props.authClient, this.props.children).then(resources =>
-            this.setState({ resources }),
-        );
+        applyPermissionsToResources({ authClient: this.props.authClient, resources: this.props.children })
+            .then(resources => this.setState({ resources }))
+            .catch(error => console.error(error));
     }
 
     render() {

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -69,7 +69,6 @@ export const applyPermissionsToResources = async ({
     const newResources = await Promise.all(
         Children.map(resources, resource => applyPermissionsToResource({ authClient, resource })),
     );
-
     return newResources.filter(resource => !!resource);
 };
 

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -1,0 +1,75 @@
+import React, { Children, Component } from 'react';
+import PropTypes from 'prop-types';
+import { Admin as OriginalAdmin, Resource } from 'admin-on-rest';
+import AuthProvider from './AuthProvider';
+import { AUTH_GET_PERMISSIONS } from './constants';
+
+export const applyPermissionsToResource = async (authClient, resource) => {
+    if (resource.props.permission && !await authClient(AUTH_GET_PERMISSIONS, resource.props.permission)) {
+        return false;
+    }
+
+    const newResource = {
+        name: resource.props.name,
+        icon: resource.props.icon,
+        options: resource.props.options,
+        checkCredentials: resource.props.checkCredentials,
+        list: !resource.props.listPermission || (await authClient(AUTH_GET_PERMISSIONS, resource.props.listPermission))
+            ? resource.props.list
+            : null,
+        create: !resource.props.createPermission ||
+            (await authClient(AUTH_GET_PERMISSIONS, resource.props.createPermission))
+            ? resource.props.create
+            : null,
+        edit: !resource.props.editPermission || (await authClient(AUTH_GET_PERMISSIONS, resource.props.editPermission))
+            ? resource.props.edit
+            : null,
+        show: !resource.props.showPermission || (await authClient(AUTH_GET_PERMISSIONS, resource.props.showPermission))
+            ? resource.props.show
+            : null,
+        remove: !resource.props.removePermission ||
+            (await authClient(AUTH_GET_PERMISSIONS, resource.props.removePermission))
+            ? resource.props.remove
+            : null,
+    };
+
+    return newResource;
+};
+
+export const applyPermissionsToResources = async (authClient, resources) => {
+    const newResources = await Promise.all(
+        Children.map(resources, resource => applyPermissionsToResource(authClient, resource)),
+    );
+
+    return newResources.filter(resource => !!resource);
+};
+
+export default class Admin extends Component {
+    static propTypes = {
+        authClient: PropTypes.func.isRequired,
+        children: PropTypes.node.isRequired,
+    };
+
+    state = { resources: false };
+
+    componentWillMount() {
+        applyPermissionsToResources(this.props.authClient, this.props.children).then(resources =>
+            this.setState({ resources }),
+        );
+    }
+
+    render() {
+        const { authClient, ...props } = this.props;
+        const { resources } = this.state;
+
+        if (!resources) return null;
+
+        return (
+            <AuthProvider authClient={authClient}>
+                <OriginalAdmin {...props}>
+                    {resources.map(resource => <Resource key={resource.name} {...resource} />)}
+                </OriginalAdmin>
+            </AuthProvider>
+        );
+    }
+}

--- a/src/Admin.spec.js
+++ b/src/Admin.spec.js
@@ -7,7 +7,7 @@ import {
 } from './Admin';
 
 describe('<Admin>', () => {
-    describe('applyPermissionsToAction', () => {
+    describe('defaultApplyPermissionsToAction', () => {
         it('resolves to the action component if no permissions attributes are defined', async () => {
             const result = await defaultApplyPermissionsToAction({
                 permissions: [],
@@ -133,7 +133,7 @@ describe('<Admin>', () => {
     describe('applyPermissionsToResources', () => {
         it('resolves to filtered resources', async () => {
             const applyPermissionsToResource = createSpy().andCall(
-                (authClient, res) => (res === 'resource1' ? res : false),
+                ({ resource }) => (resource === 'resource1' ? resource : false),
             );
 
             const resources = await applyPermissionsToResources({
@@ -143,8 +143,14 @@ describe('<Admin>', () => {
             });
 
             expect(resources).toEqual(['resource1']);
-            expect(applyPermissionsToResource).toHaveBeenCalledWith('authClientImpl', 'resource1');
-            expect(applyPermissionsToResource).toHaveBeenCalledWith('authClientImpl', 'resource2');
+            expect(applyPermissionsToResource).toHaveBeenCalledWith({
+                authClient: 'authClientImpl',
+                resource: 'resource1',
+            });
+            expect(applyPermissionsToResource).toHaveBeenCalledWith({
+                authClient: 'authClientImpl',
+                resource: 'resource2',
+            });
         });
     });
 });

--- a/src/Admin.spec.js
+++ b/src/Admin.spec.js
@@ -1,0 +1,150 @@
+import expect, { createSpy } from 'expect';
+
+import {
+    defaultApplyPermissionsToAction,
+    defaultApplyPermissionsToResource,
+    applyPermissionsToResources,
+} from './Admin';
+
+describe('<Admin>', () => {
+    describe('applyPermissionsToAction', () => {
+        it('resolves to the action component if no permissions attributes are defined', async () => {
+            const result = await defaultApplyPermissionsToAction({
+                permissions: [],
+                resource: { props: { list: 'listComponent' } },
+                action: 'list',
+            });
+
+            expect(result).toEqual('listComponent');
+        });
+
+        it('resolves to the action component if permissions attributes are defined and resolvePermission matches', async () => {
+            const resolvePermission = createSpy().andReturn(() => Promise.resolve({ matched: true }));
+
+            const result = await defaultApplyPermissionsToAction({
+                permissions: [],
+                resource: { props: { list: 'listComponent', listPermissions: 'foo' } },
+                action: 'list',
+                resolvePermission,
+            });
+
+            expect(result).toEqual('listComponent');
+        });
+
+        it('resolves to null if permissions attributes are defined and resolvePermission does not match', async () => {
+            const resolvePermission = createSpy().andReturn(() => Promise.resolve({ matched: false }));
+
+            const result = await defaultApplyPermissionsToAction({
+                permissions: [],
+                resource: { props: { list: 'listComponent', listPermissions: 'foo' } },
+                action: 'list',
+                resolvePermission,
+            });
+
+            expect(result).toEqual(null);
+        });
+    });
+
+    describe('defaultApplyPermissionsToResource', () => {
+        it('resolves to the resource if no permissions attributes are defined', async () => {
+            const authClient = createSpy().andReturn(Promise.resolve('foo'));
+            const result = await defaultApplyPermissionsToResource({
+                authClient,
+                resource: {
+                    props: {
+                        name: 'aResource',
+                        icon: 'anIcon',
+                        options: 'someOptions',
+                        checkCredentials: 'doesCheckCredentials',
+                        list: 'listComponent',
+                        create: 'createComponent',
+                        edit: 'editComponent',
+                        show: 'showComponent',
+                        remove: 'removeComponent',
+                    },
+                },
+            });
+
+            expect(result).toEqual({
+                name: 'aResource',
+                icon: 'anIcon',
+                options: 'someOptions',
+                checkCredentials: 'doesCheckCredentials',
+                list: 'listComponent',
+                create: 'createComponent',
+                edit: 'editComponent',
+                show: 'showComponent',
+                remove: 'removeComponent',
+            });
+        });
+
+        it('resolves to the resource with filtered actions if permissions attributes are defined', async () => {
+            const authClient = createSpy().andReturn(Promise.resolve(['list', 'show']));
+            const result = await defaultApplyPermissionsToResource({
+                authClient,
+                resource: {
+                    props: {
+                        name: 'aResource',
+                        icon: 'anIcon',
+                        options: 'someOptions',
+                        checkCredentials: 'doesCheckCredentials',
+                        list: 'listComponent',
+                        listPermissions: 'list',
+                        create: 'createComponent',
+                        createPermissions: 'foo',
+                        edit: 'editComponent',
+                        editPermissions: 'foo',
+                        show: 'showComponent',
+                        showPermissions: 'show',
+                        showResolve: () => Promise.resolve(false),
+                        remove: 'removeComponent',
+                        removePermissions: 'foo',
+                        removeResolve: () => true,
+                    },
+                },
+            });
+
+            expect(result).toEqual({
+                name: 'aResource',
+                icon: 'anIcon',
+                options: 'someOptions',
+                checkCredentials: 'doesCheckCredentials',
+                list: 'listComponent',
+                create: null,
+                edit: null,
+                show: null,
+                remove: 'removeComponent',
+            });
+        });
+
+        it('resolves to false if permissions attribute is defined and resolvePermission does not match', async () => {
+            const authClient = createSpy().andReturn(Promise.resolve('foo'));
+            const resolvePermission = createSpy().andReturn(() => Promise.resolve({ matched: false }));
+            const result = await defaultApplyPermissionsToResource({
+                authClient,
+                resource: { props: { permissions: 'bar' } },
+                resolvePermission,
+            });
+
+            expect(result).toEqual(false);
+        });
+    });
+
+    describe('applyPermissionsToResources', () => {
+        it('resolves to filtered resources', async () => {
+            const applyPermissionsToResource = createSpy().andCall(
+                (authClient, res) => (res === 'resource1' ? res : false),
+            );
+
+            const resources = await applyPermissionsToResources({
+                authClient: 'authClientImpl',
+                resources: ['resource1', 'resource2'],
+                applyPermissionsToResource,
+            });
+
+            expect(resources).toEqual(['resource1']);
+            expect(applyPermissionsToResource).toHaveBeenCalledWith('authClientImpl', 'resource1');
+            expect(applyPermissionsToResource).toHaveBeenCalledWith('authClientImpl', 'resource2');
+        });
+    });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -3,4 +3,5 @@ export WithPermission from './WithPermission';
 export Permission from './Permission';
 export Loading from './Loading';
 export AuthProvider from './AuthProvider';
+export Admin from './Admin';
 export { AUTH_GET_PERMISSIONS } from './constants';


### PR DESCRIPTION
Proposal for applying permissions on the `Resource` component directly.

This addon would provide a custom `Admin` component which can make the necessary asynchronous calls to the authClient to determine whether to display a resource or any of its components.

Resource accepts the following new props:
- `permissions`: to define the permissions required for the whole resource
- `resolve`: function called to check whether permissions are ok
- `exact`: Boolean for exact match when `permissions` is an array

Additionally, it accepts the same set of props for each action (`list`, `create`, `edit`, `show` and `remove`) with each prop prefixed by the action name, for example: `listPermissions`, `listResolve` and `listExact`.

- [x] Implementation
- [x] Tests
- [x] Documentation

Fixes #13 